### PR TITLE
New: Add shared workflow files (fix #1)

### DIFF
--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,4 +1,4 @@
-name: Reusable Add to Project Workflow
+name: Add to Project Workflow
 
 on:
   workflow_call:

--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,5 +1,4 @@
 name: Add to Project Workflow
-
 on:
   workflow_call:
     inputs:
@@ -8,7 +7,6 @@ on:
         required: false
         type: string
         default: 'https://github.com/orgs/cgkineo/projects/3/views/1'
-
 jobs:
   add-to-project:
     name: Add to main project

--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,0 +1,20 @@
+name: Reusable Add to Project Workflow
+
+on:
+  workflow_call:
+    inputs:
+      project-url:
+        description: 'GitHub project URL'
+        required: false
+        type: string
+        default: 'https://github.com/orgs/cgkineo/projects/3/views/1'
+
+jobs:
+  add-to-project:
+    name: Add to main project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.1.0
+        with:
+          project-url: ${{ inputs.project-url }}
+          github-token: ${{ secrets.ADDTOPROJECT_TOKEN }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,4 +1,4 @@
-name: Reusable Release Workflow
+name: Release Workflow
 
 on:
   workflow_call:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,41 @@
+name: Reusable Release Workflow
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version to use'
+        required: false
+        type: string
+        default: 'lts/*'
+      working-directory:
+        description: 'Working directory for the workflow'
+        required: false
+        type: string
+        default: '.'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Release
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -16,15 +16,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-
       - name: Install dependencies
         run: npm ci
-
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,5 +1,4 @@
 name: Release Workflow
-
 on:
   workflow_call:
     inputs:
@@ -8,7 +7,6 @@ on:
         required: false
         type: string
         default: 'lts/*'
-
 jobs:
   release:
     name: Release

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,11 +8,6 @@ on:
         required: false
         type: string
         default: 'lts/*'
-      working-directory:
-        description: 'Working directory for the workflow'
-        required: false
-        type: string
-        default: '.'
 
 jobs:
   release:
@@ -30,11 +25,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
-        working-directory: ${{ inputs.working-directory }}
         run: npm ci
 
       - name: Release
-        working-directory: ${{ inputs.working-directory }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fix #1 

### New
- Adds shared GitHub workflow files.
- cgkineo repositories can now reference the workflows in this repo (see below for examples).

_addtomainproject.yml_

- Adds to GitHub project
- Optionally pass in `project-url` for the GitHub project URL. Defaults to `https://github.com/orgs/cgkineo/projects/3/views/1`

_releases.yml_

- Creates new semantic release version
- Optionally pass in `node-version`. Defaults to `lts/*` (latest)

### Examples

The following examples are how the workflow files should look in another plugin.

_addtomainproject.yml_

```yaml
name: Add to main project
on:
  issues:
    types:
      - opened
  pull_request:
    types:
      - opened
jobs:
  add-to-project:
    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master
    secrets: inherit
```

Or to use a different project, pass in a `project-url` value in the `with` section:

```yaml
name: Add to main project

on:
  issues:
    types:
      - opened
  pull_request:
    types:
      - opened

jobs:
  add-to-project:
    uses: cgkineo/cgkineo/.github/workflows/addtomainproject.yml@master
    with:
      project-url: 'https://github.com/orgs/cgkineo/projects/5/views/1'
    secrets: inherit
```
_releases.yml_

```yaml
name: Release
on:
  push:
    branches:
      - master
jobs:
  release:
    uses: cgkineo/.github/.github/workflows/releases.yml@master
    secrets: inherit
```

### Tokens
Private cgkineo repos that publish to npm must have their own NPM_TOKEN set. They cannot share the organization one. NEEDS confirmation.


### Related PR
https://github.com/cgkineo/test-brad/pull/4
