### PR TITLE
Update: bump checkout and setup-node to v6 for Node 24

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -17,11 +17,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
       - name: Install dependencies


### PR DESCRIPTION
Addresses cgkineo/cgkineo#11

> **Note:** This PR is in `cgkineo/.github` while the tracking issue is in `cgkineo/cgkineo`. Cross-repo references do not auto-close, so **cgkineo/cgkineo#11 must be closed manually after this PR is merged.**

### Update
- Bump `actions/checkout` v4 -> v6 and `actions/setup-node` v4 -> v6 in the shared `releases.yml`, so the actions run on Node 24 (GitHub forces Node 20 actions to Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16).
- This is the action runtime only; the `node-version` input stays `lts/*` (the Node used to run the project / semantic-release is unchanged).
- `actions/add-to-project` stays at `v2.0.0` (latest; no Node 24 build available yet, will be auto-forced).

Reusable workflow, so every consuming repo inherits this on its next run.

Posted via collaboration with Claude Code
